### PR TITLE
feat(images): Improve `ItemTile` and Images

### DIFF
--- a/components/DragDropTierList.tsx
+++ b/components/DragDropTierList.tsx
@@ -62,7 +62,7 @@ const TierItems = memo<{
                   {...provided.draggableProps}
                   {...provided.dragHandleProps}
                   className={`
-                    m-1 rounded-md bg-card
+                    m-1 rounded-md 
                     ${snapshot.isDragging ? 'shadow-md ring-2' : ''}
                   `}
                   style={{

--- a/components/ShareButton.tsx
+++ b/components/ShareButton.tsx
@@ -11,6 +11,7 @@ import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/c
 import {Separator} from "@/components/ui/separator";
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@/components/ui/tooltip";
 import {Collapsible, CollapsibleContent, CollapsibleTrigger} from "@/components/ui/collapsible";
+import {Skeleton} from "@/components/ui/skeleton";
 
 type SocialPlatform = 'facebook' | 'twitter';
 type CaptureMethod = 'original' | 'pro';
@@ -127,7 +128,7 @@ const ShareButton: React.FC = () => {
       <PopoverContent className="w-[320px]" ref={popoverRef}>
         <div className="grid gap-5">
           <h3 className="scroll-m-20 text-xl font-semibold tracking-tight">
-            Share Tier List
+            Share Your Tier List Rankings
           </h3>
           <div className="space-y-2">
             <div className="flex flex-row space-x-2">
@@ -178,7 +179,7 @@ const ShareButton: React.FC = () => {
               </CollapsibleContent>
             </Collapsible>
           </div>
-          {imageBlob && (
+          {imageBlob ? (
             <div className="relative w-full h-48">
               <Image
                 src={URL.createObjectURL(imageBlob)}
@@ -186,6 +187,14 @@ const ShareButton: React.FC = () => {
                 fill
                 style={{objectFit: "contain"}}
               />
+            </div>
+          ) : (
+            <div className="flex items-center">
+              <div className="space-y-2">
+                <Skeleton className="h-6 w-[280px]"/>
+                <Skeleton className="h-6 w-[280px]"/>
+                <Skeleton className="h-6 w-[280px]"/>
+              </div>
             </div>
           )}
           <div>

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
### Fixes: #35 

Also:
- Introduces `backdrop-blur` but with some bandaid hacks to workaround the performance hits.
- Adds a loading skeleton to `ShareButton`.